### PR TITLE
chore: upgrade to libs-versions:2023.04.00

### DIFF
--- a/devtools/build.gradle.kts
+++ b/devtools/build.gradle.kts
@@ -64,7 +64,7 @@ dependencies {
 }
 
 group = "com.github.foodiestudio"
-version = "0.1.0"
+version = "0.1.1"
 
 publishing {
     publications {

--- a/devtools/build.gradle.kts
+++ b/devtools/build.gradle.kts
@@ -54,11 +54,10 @@ android {
 dependencies {
     val composeBom = platform(sharedLibs.compose.bom)
     implementation(composeBom)
-    implementation(sharedLibs.bundles.compose)
+    implementation(sharedLibs.bundles.compose.core)
     implementation(sharedLibs.accompanist.systemuicontroller)
     implementation(sharedLibs.accompanist.navigation.material)
     implementation(sharedLibs.okio)
-    implementation(sharedLibs.navigation)
     api(sharedLibs.startup)
 
     testImplementation(sharedLibs.junit)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,13 +15,12 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("sharedLibs") {
-            from("io.github.foodiestudio:libs-versions:2023.01.00")
+            from("io.github.foodiestudio:libs-versions:2023.04.00")
             library("startup", "androidx.startup:startup-runtime:1.1.1")
             val accompanistVersion = "0.30.1"
             library("accompanist-systemuicontroller", "com.google.accompanist:accompanist-systemuicontroller:$accompanistVersion")
             library("accompanist-navigation-material", "com.google.accompanist:accompanist-navigation-material:$accompanistVersion")
-            library("okio", "com.squareup.okio:okio:3.5.0")
-            library("navigation", "androidx.navigation:navigation-compose:2.6.0")
+            library("okio", "com.squareup.okio:okio:3.3.0")
         }
     }
 }


### PR DESCRIPTION
Downgrade the `navigation` and `okio` versions in order to update `Kotlin` dependencies to version **1.8.10**.